### PR TITLE
signData function is now using UTF8 encoding instead of Binary

### DIFF
--- a/azuqua.js
+++ b/azuqua.js
@@ -77,7 +77,7 @@ var signData = function(accessSecret, data, verb, _path, timestamp){
   else if(typeof data === "object")
     data = JSON.stringify(data);
   var meta = [verb.toLowerCase(), _path, timestamp].join(":");
-  return crypto.createHmac("sha256", accessSecret).update(meta + data).digest("hex");
+  return crypto.createHmac("sha256", accessSecret).update(Buffer(meta + data, 'utf-8')).digest("hex");
 };
 
 var addGetParameter = function(_path, key, value){
@@ -131,6 +131,13 @@ var Azuqua = function(accessKey, accessSecret, httpOptions){
   }
 
   self.client = new RestJS({ protocol: protocol });
+  
+  self.signData = function(data, verb, path, timestamp) {
+    if(!self.account.accessSecret)
+      throw new Error("Account information not found");
+    
+    return signData(self.account.accessSecret, data, verb, path, timestamp);
+  };
 
   self.makeRequest = function(options, params, callback){
     if(!self.account || !self.account.accessKey || !self.account.accessSecret)

--- a/test/test.js
+++ b/test/test.js
@@ -110,6 +110,40 @@ describe("Client configuration tests", function(){
 
 });
 
+describe("Signing function", function() {
+	describe("With latin charset only", function(){
+		var azuqua = new Azuqua(testCredentials.accessKey, testCredentials.accessSecret);
+		
+		var hash = azuqua.signData("Hello", "POST", "path", "timestamp");
+			
+		it("Hash should match", function(){
+			assert.equal(hash, "59423b18b5800daaf3ef9eb68b9a35501acfedd5ed0b0de7d4fd9b4c360fed3d");
+		});
+	});
+	
+	describe("With UTF-8 characters", function(){
+		var azuqua = new Azuqua(testCredentials.accessKey, testCredentials.accessSecret);
+		
+		var hash = azuqua.signData("你好", "POST", "path", "timestamp");
+		
+		it("Hash should match", function(){
+			assert.equal(hash, "2424f6a6ac168badb8096aae779a6c91287f2e20c19a49598c6c679796b0753a");
+		});
+	});
+	
+	describe("With invalid configuration", function(){
+		var azuqua = new Azuqua(testCredentials.accessKey, '');
+		
+		var fn = function() {
+			return azuqua.signData("Hello", "POST", "path", "timestamp");
+		};
+		
+		it("Should throw Error", function(){
+			assert.throw(fn, Error);
+		});
+	});
+});
+
 describe("Client API function tests", function(){
 	this.timeout(60000);
 


### PR DESCRIPTION
Fix #6 

By [default](https://nodejs.org/api/crypto.html#crypto_hash_update_data_input_encoding) `update` is using Binary encoding.

`signData` is now using UT8 encoding which will make the hash more portable with other languages.

`With UTF-8 characters` was failing before I made my changes.